### PR TITLE
Allow for table lines width and color changes

### DIFF
--- a/nodeProcessing.go
+++ b/nodeProcessing.go
@@ -449,8 +449,6 @@ func (r *PdfRenderer) processTableCell(node *bf.Node, entering bool) {
 			textStyle: r.Normal, listkind: notlist,
 			leftMargin: r.cs.peek().leftMargin}
 		if node.TableCellData.IsHeader {
-			r.Pdf.SetDrawColor(128, 0, 0)
-			r.Pdf.SetLineWidth(.3)
 			x.isHeader = true
 			x.textStyle = r.THeader
 			r.setStyler(r.THeader)


### PR DESCRIPTION
Hi!
Just trivial change. By deleting this two lines we enable library user to change table lines color and width.
It can be set like that:
``` go
pf := mdtopdf.NewPdfRenderer("", "A4", pdffile, "trace.log")
pf.Pdf.SetDrawColor(150, 150, 150)                                                                                                    
pf.Pdf.SetLineWidth(1)
```

Thank you for great library!