### PR TITLE
Call `r.setStyler(r.Normal)()` rather than `r.setStyler(currentStyle)`

### DIFF
--- a/nodeProcessing.go
+++ b/nodeProcessing.go
@@ -113,8 +113,7 @@ func (r *PdfRenderer) processCodeblock(node *bf.Node) {
 					case highlight.Groups["default"]:
 						fallthrough
 					case highlight.Groups[""]:
-						currentStyle := r.cs.peek().textStyle
-						r.setStyler(currentStyle)
+						r.setStyler(r.Normal)
 					case highlight.Groups["statement"]:
 						fallthrough
 					case highlight.Groups["green"]:
@@ -170,8 +169,7 @@ func (r *PdfRenderer) processCodeblock(node *bf.Node) {
 					case highlight.Groups["high.green"]:
 						r.Pdf.SetTextColor(82, 204, 0)
 					default:
-						currentStyle := r.cs.peek().textStyle
-						r.setStyler(currentStyle)
+						r.setStyler(r.Normal)
 					}
 				}
 				r.Pdf.Write(5, string(c))


### PR DESCRIPTION
When the text matches no colouring group, it's better to call `r.setStyler(r.Normal)()`,