### PR TITLE
See https://github.com/mandolyte/mdtopdf/issues/49

### DIFF
--- a/mdtopdf.go
+++ b/mdtopdf.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
+
 	"strings"
 
 	"github.com/go-pdf/fpdf"
@@ -338,7 +338,8 @@ func (r *PdfRenderer) Run(content []byte) error {
 		s = []byte(r.unicodeTranslator(string(s)))
 	}
 
-	exts := parser.CommonExtensions // parser.OrderedListStart | parser.NoEmptyLineBeforeBlock
+	// exts := parser.CommonExtensions // parser.OrderedListStart | parser.NoEmptyLineBeforeBlock
+	exts := parser.NoIntraEmphasis | parser.Tables | parser.FencedCode | parser.Autolink | parser.Strikethrough | parser.SpaceHeadings | parser.HeadingIDs | parser.BackslashLineBreak | parser.DefinitionLists
 	p := parser.NewWithExtensions(exts)
 	doc := markdown.Parse(s, p)
 	_ = markdown.Render(doc, r)
@@ -450,8 +451,10 @@ func (r *PdfRenderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.
 		r.processTableRow(node, entering)
 	case *ast.TableCell:
 		r.processTableCell(*node, entering)
+	/*case *ast.Math:
+	r.processMath(node)*/
 	default:
-		panic("Unknown node type " + reflect.TypeOf(node).Name())
+		fmt.Printf("Unknown node type: %T. Skipping\n", node)
 	}
 	return ast.GoToNext
 }

--- a/nodeProcessing.go
+++ b/nodeProcessing.go
@@ -88,6 +88,13 @@ func (r *PdfRenderer) processText(node *ast.Text) {
 	}
 }
 
+// This is a stub implementation. For now, the MathAjax extension is disabled.
+func (r *PdfRenderer) processMath(node *ast.Math) {
+	currentStyle := r.cs.peek().textStyle
+	s := string(node.Literal)
+	r.write(currentStyle, s)
+}
+
 func (r *PdfRenderer) outputUnhighlightedCodeBlock(codeBlock string) {
 	r.cr() // start on next line!
 	r.setStyler(r.Backtick)


### PR DESCRIPTION
See https://github.com/mandolyte/mdtopdf/issues/49

For now, I've disabled the `MathAJax` extension, though I created a stub in nodeProcessing.go for future consideration. Also, replaced the `panic()` call with `fmt.Printf()` when node.(type) does not match any of the supported types. This way, people could report such issues and at least get some useful output, rather than a crash.