### PR TITLE
As of Go 1.16, ioutil.ReadAll is deprecated and simply calls io.ReadAll

### DIFF
--- a/cmd/md2pdf/md2pdf.go
+++ b/cmd/md2pdf/md2pdf.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -47,7 +47,7 @@ func processRemoteInputFile(url string) ([]byte, error) {
 	if resp.StatusCode != 200 {
 		return nil, errors.New("Received non 200 response code: " + fmt.Sprintf("HTTP %d", resp.StatusCode))
 	}
-	content, rerr := ioutil.ReadAll(resp.Body)
+	content, rerr := io.ReadAll(resp.Body)
 	return content, rerr
 }
 
@@ -94,7 +94,7 @@ func main() {
 	var err error
 	var inputBaseURL string
 	if *input == "" {
-		content, err = ioutil.ReadAll(os.Stdin)
+		content, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -121,7 +121,7 @@ func main() {
 					log.Fatal(err)
 				}
 				for i, filePath := range files {
-					fileContents, err := ioutil.ReadFile(filePath)
+					fileContents, err := os.ReadFile(filePath)
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -131,7 +131,7 @@ func main() {
 					}
 				}
 			} else {
-				content, err = ioutil.ReadFile(*input)
+				content, err = os.ReadFile(*input)
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/mdtopdf_test.go
+++ b/mdtopdf_test.go
@@ -20,7 +20,7 @@
 package mdtopdf
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -36,7 +36,7 @@ func testit(inputf string, gohighlight bool, t *testing.T) {
 	pdffile := path.Join(inputd, strings.TrimSuffix(path.Base(input), ".text"))
 	pdffile += ".pdf"
 
-	content, err := ioutil.ReadFile(input)
+	content, err := os.ReadFile(input)
 	if err != nil {
 		t.Errorf("%v:%v", input, err)
 	}

--- a/nodeProcessing.go
+++ b/nodeProcessing.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -120,7 +119,7 @@ func (r *PdfRenderer) processCodeblock(node ast.CodeBlock) {
 	if strings.HasPrefix(string(node.Literal), "<script") && string(node.Info) == "html" {
 		node.Info = []byte("javascript")
 	}
-	syntaxFile, lerr := ioutil.ReadFile(r.SyntaxHighlightBaseDir + "/" + string(node.Info) + ".yaml")
+	syntaxFile, lerr := os.ReadFile(r.SyntaxHighlightBaseDir + "/" + string(node.Info) + ".yaml")
 	if lerr != nil {
 		r.outputUnhighlightedCodeBlock(string(node.Literal))
 		return
@@ -393,7 +392,7 @@ func (r *PdfRenderer) processImage(node ast.Image, entering bool) {
 		mtype, err := mimetype.DetectFile(destination)
 		if mtype.Is("image/svg+xml") {
 			re := regexp.MustCompile(`<svg\s*.*\s*width="([0-9\.]+)"\sheight="([0-9\.]+)".*>`)
-			contents, _ := ioutil.ReadFile(destination)
+			contents, _ := os.ReadFile(destination)
 			matches := re.FindStringSubmatch(string(contents))
 			tf, err := os.CreateTemp(tempDir, "*.svg")
 			if err != nil {


### PR DESCRIPTION
See https://github.com/mandolyte/mdtopdf/pull/58#issuecomment-2225618262