### PR TITLE
fix some table rendering issues empty cells in tables

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -34,6 +34,7 @@ const (
 var cellwidths []float64
 var curdatacell int
 var fill = false
+var incell = false
 
 func (n listType) String() string {
 	switch n {
@@ -63,6 +64,10 @@ type containerState struct {
 
 	// populated if table cell
 	isHeader bool
+
+	// populated if table cell (apply styles first)
+	cellInnerString      string
+	cellInnerStringStyle *Styler
 }
 
 type states struct {


### PR DESCRIPTION
Some minor tweaks for table rendering:
- scan all tables and find the max width per column ( #20 )
- refactor text rendering when in a table cell to fix bold/italic breaking table layout, though still not 100% correct (last markup overrides the cell style)
- render empty cells (#61)




